### PR TITLE
Update for torch compatibility headers

### DIFF
--- a/3rdparty/cmake/FindPaddle.cmake
+++ b/3rdparty/cmake/FindPaddle.cmake
@@ -54,6 +54,12 @@ if(NOT Paddle_FOUND)
     set(PADDLE_INCLUDE_DIRS)
     list(APPEND PADDLE_INCLUDE_DIRS "${Paddle_ROOT}/include")
     list(APPEND PADDLE_INCLUDE_DIRS "${Paddle_ROOT}/include/third_party")
+    if(EXISTS "${Paddle_ROOT}/include/paddle/phi/api/include/compat")
+        list(APPEND PADDLE_INCLUDE_DIRS "${Paddle_ROOT}/include/paddle/phi/api/include/compat")
+    endif()
+    if(EXISTS "${Paddle_ROOT}/include/paddle/phi/api/include/compat/torch/csrc/api/include")
+        list(APPEND PADDLE_INCLUDE_DIRS "${Paddle_ROOT}/include/paddle/phi/api/include/compat/torch/csrc/api/include")
+    endif()
     list(APPEND PADDLE_INCLUDE_DIRS "${Python_INCLUDE}")
 
     if(BUILD_CUDA_MODULE)
@@ -77,13 +83,13 @@ if(NOT Paddle_FOUND)
     if(BUILD_CUDA_MODULE)
         find_library(CUDART_LIB NAMES cudart PATHS "${CUDAToolkit_LIBRARY_DIR}")
         list(APPEND PADDLE_LIBRARY_DIRS "${CUDART_LIB}")
-    endif() 
+    endif()
 
     # handle compile flags
     set(PADDLE_CXX_FLAGS)
     if(BUILD_CUDA_MODULE)
         set(PADDLE_CXX_FLAGS "-DPADDLE_WITH_CUDA ${PADDLE_CXX_FLAGS}")
-    endif() 
+    endif()
 
     set_target_properties(paddle PROPERTIES
         IMPORTED_LOCATION "${PADDLE_LIB}"

--- a/README.md
+++ b/README.md
@@ -50,14 +50,20 @@ mkdir build
 cd build
 
 # Build on develop
-cmake  -DBUILD_CUDA_MODULE=ON \
+cmake  -DCMAKE_CUDA_HOST_COMPILER=/usr/bin/gcc-9 \  # specify gcc/g++ in your environment, 9 or 11 recommended
+       -DCMAKE_C_COMPILER=/usr/bin/gcc-9 \  # specify gcc/g++ in your environment, 9 or 11 recommended
+       -DCMAKE_CXX_COMPILER=/usr/bin/g++-9 \  # specify gcc/g++ in your environment, 9 or 11 recommended
+       -DBUILD_CUDA_MODULE=ON \
        -DBUILD_PADDLE_OPS=ON  \
        -DGLIBCXX_USE_CXX11_ABI=ON \
        -DBUNDLE_OPEN3D_ML=OFF \
        ..
 
 # Build on release (support CUDA archs: Pascal, Volta, Turing and Ampere.)
-cmake  -DBUILD_CUDA_MODULE=ON \
+cmake  -DCMAKE_CUDA_HOST_COMPILER=/usr/bin/gcc-9 \  # specify gcc/g++ in your environment, 9 or 11 recommended
+       -DCMAKE_C_COMPILER=/usr/bin/gcc-9 \  # specify gcc/g++ in your environment, 9 or 11 recommended
+       -DCMAKE_CXX_COMPILER=/usr/bin/g++-9 \  # specify gcc/g++ in your environment, 9 or 11 recommended
+       -DBUILD_CUDA_MODULE=ON \
        -DBUILD_COMMON_CUDA_ARCHS=ON \
        -DBUILD_PADDLE_OPS=ON  \
        -DGLIBCXX_USE_CXX11_ABI=ON \

--- a/python/open3d/ml/paddle/__init__.py
+++ b/python/open3d/ml/paddle/__init__.py
@@ -17,8 +17,9 @@ if _verp(_paddle.__version__).release[:2] != _o3d_paddle_version.release[:2]:
     match_paddle_ver = '.'.join(
         str(v) for v in _o3d_paddle_version.release[:2] + ('*',))
     warnings.warn(
-        f"Version mismatch: Open3D needs Paddle version {match_paddle_ver}, but "
-        f"version {_paddle.__version__} is installed",
+        f"Version mismatch detected: Open3D requires Paddle version {match_paddle_ver}, "
+        f"but version {_paddle.__version__} is installed. "
+        f"Note: Compatibility issues may arise if using Paddle < 3.0.0",
         category=UserWarning)
 
 _loaded = False


### PR DESCRIPTION
1. Paddle 在近期通过兼容性项目，支持了 torch 的C++头文件，因此在cmake中添加了对应的头文件路径，顺便修改了paddle版本警告内容
2. 更新README中编译脚本，添加指定gcc/g++的说明

@BeingGod